### PR TITLE
navigationFallback should not be set by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ module.exports = (bundler) => {
 					globDirectory: outDir,
 					globPatterns: ['**\/*.{html,js,css,jpg,png}'],
 					swDest: swDest,
-					navigateFallback: publicURL+"/index.html",
 					clientsClaim: true,
 					skipWaiting: true,
 					"templatedUrls": {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function fixRegexpArray(arr, key){
 module.exports = (bundler) => {
 
 	const outDir = bundler.options.outDir;
-	const publicURL = bundler.options.publicURL;
+	let   publicURL = bundler.options.publicURL;
 	const swDest = path.join(outDir,'sw.js');
 
 


### PR DESCRIPTION
There are 2 issues.

1. navigationFallback can't be set back to null from package.json, so you should not assign it  a default value.
2. 0ff3490807a76f5567a896c018f70780b3dd455b generates an error because publicURL is const, so declare it as 'let'.  
 
